### PR TITLE
Cap signal strength if it is ridiculous

### DIFF
--- a/lib/Calculation.ts
+++ b/lib/Calculation.ts
@@ -42,10 +42,16 @@ class Calculation {
 	 * Converts a distance in meters to a signal strength in dBm.
 	 */
 	distanceToSignalStrength(distance: number): number {
-		return (
+		const capAt = -1;
+		let signalStrength = (
 			this.firstStrength -
 			10 * this.pathLossExponent * Math.log(distance / this.firstDistance)
 		);
+		if(signalStrength > capAt){
+			console.warn(`Capped signal strength from ${signalStrength} to ${capAt}`);
+			signalStrength = capAt;
+		}
+		return signalStrength;
 	}
 
 	/**


### PR DESCRIPTION
If the distance is smaller than ~0.3, the signal strength becomes positive, which screws up the measurements. This is a temporary fix to make the data more accurate.